### PR TITLE
fix: Fix typo for z axis label

### DIFF
--- a/src/components/Experiments/ExperimentResults/ExperimentResults.component.js
+++ b/src/components/Experiments/ExperimentResults/ExperimentResults.component.js
@@ -114,7 +114,7 @@ export const ExperimentResults = (props: TypeProps) => {
         {activeExperiment.metricsList.length >= 3 && (
           <div className={style.metric}>
             <Icon icon="zAxis" width={18} cssClass={style.metricIcon} />
-            Y-AXIS METRIC
+            Z-AXIS METRIC
             <div className={style.dropdown}>
               <ListSearch
                 value={activeExperiment.zAxisMetric}


### PR DESCRIPTION
The z axis has a label of y axis:
<img width="671" alt="image" src="https://user-images.githubusercontent.com/4570765/92975157-51304b00-f44d-11ea-8c6e-f695500dbc1f.png">

Signed-off-by: Brad Beam <brad.beam@carbonrelay.com>